### PR TITLE
Add text HOC with presets

### DIFF
--- a/src/components/Shared/Text/Text.tsx
+++ b/src/components/Shared/Text/Text.tsx
@@ -1,0 +1,21 @@
+import React, { useCallback } from 'react';
+import { TextProps, Text as ReactNativeText } from 'react-native';
+import { presets as textPresets, TextPresets } from '@shared/Text/presets';
+
+type Props = TextProps & {
+  presets?: TextPresets | Array<TextPresets>;
+};
+
+export const Text: React.FC<Props> = ({ presets = 'body1', style: styleOverride, ...rest }) => {
+  const parsingPresets = useCallback(() => {
+    if (typeof presets === 'object') {
+      return presets.map(item => textPresets[item]);
+    }
+
+    return [textPresets[presets]];
+  }, [presets]);
+
+  const styles = [...parsingPresets(), styleOverride];
+
+  return <ReactNativeText style={styles} {...rest} />;
+};

--- a/src/components/Shared/Text/Text.tsx
+++ b/src/components/Shared/Text/Text.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { memo, useCallback } from 'react';
 import { TextProps, Text as ReactNativeText } from 'react-native';
 import { presets as textPresets, TextPresets } from '@shared/Text/presets';
 
@@ -6,7 +6,7 @@ type Props = TextProps & {
   presets?: TextPresets | Array<TextPresets>;
 };
 
-export const Text: React.FC<Props> = ({ presets = 'body1', style: styleOverride, ...rest }) => {
+export const Text: React.FC<Props> = memo(({ presets = 'body1', style: styleOverride, ...rest }) => {
   const parsingPresets = useCallback(() => {
     if (typeof presets === 'object') {
       return presets.map(item => textPresets[item]);
@@ -18,4 +18,4 @@ export const Text: React.FC<Props> = ({ presets = 'body1', style: styleOverride,
   const styles = [...parsingPresets(), styleOverride];
 
   return <ReactNativeText style={styles} {...rest} />;
-};
+});

--- a/src/components/Shared/Text/index.ts
+++ b/src/components/Shared/Text/index.ts
@@ -1,0 +1,1 @@
+export * from './Text';

--- a/src/components/Shared/Text/presets.ts
+++ b/src/components/Shared/Text/presets.ts
@@ -1,0 +1,68 @@
+import { StyleSheet } from 'react-native';
+import { resizePixels } from '@/utils';
+
+export const presets = StyleSheet.create(
+  resizePixels({
+    h1: {
+      fontSize: 36,
+      fontWeight: 'bold',
+      lineHeight: 42,
+      letterSpacing: -(36 * 0.02),
+    },
+    h2: {
+      fontSize: 30,
+      fontWeight: 'bold',
+      lineHeight: 38,
+    },
+    subtitle1: {
+      fontSize: 24,
+      lineHeight: 32,
+    },
+    subtitle2: {
+      fontSize: 18,
+      lineHeight: 24,
+    },
+    body1: {
+      fontSize: 16,
+      lineHeight: 22,
+    },
+    body2: {
+      fontSize: 14,
+      lineHeight: 20,
+    },
+    number1: {
+      fontSize: 16,
+      lineHeight: 22,
+    },
+    number2: {
+      fontSize: 14,
+      lineHeight: 20,
+    },
+    number3: {
+      fontSize: 12,
+      lineHeight: 16,
+    },
+    caption1: {
+      fontSize: 12,
+      lineHeight: 18,
+    },
+    caption2: {
+      fontSize: 11,
+      lineHeight: 16,
+    },
+    bold: {
+      fontWeight: 'bold',
+    },
+    medium: {
+      fontWeight: '500',
+    },
+    regular: {
+      fontWeight: '400',
+    },
+    light: {
+      fontWeight: '300',
+    },
+  })
+);
+
+export type TextPresets = keyof typeof presets;

--- a/src/utils/resizePixel/resizePixel.ts
+++ b/src/utils/resizePixel/resizePixel.ts
@@ -10,7 +10,7 @@ export const resizePixel = (x: number) => {
   return (x / DESIGN_WIDTH) * SCREEN_WIDTH;
 };
 
-const NO_RESIZE_STYLE = ['flex'];
+const NO_RESIZE_STYLE = ['flex', 'fontWeight'];
 
 export const resizePixels = <T extends NamedStyles<T> | NamedStyles<any>>(styleObject: T | NamedStyles<T>): T => {
   let data = {} as any;


### PR DESCRIPTION
## 개요 및 변경 사항 <!-- 해당 Pull Request에 대한 간단한 설명 작성 -->
Text component HOC
## 관련 이슈 <!-- 해당 Pull Request에 대한 자세한 내용을 확인할 수 있는 이슈를 번호로 작성 -->

closes #12 <!-- Ex. closes #1 -->

## 스크린샷 <!-- 빠른 참고 용 -->

<span>
<img width="200" alt="typography" src="https://user-images.githubusercontent.com/45376611/169307956-10e6b9ff-18df-4c0d-9b40-d060f507996d.png">
</span>
<span>
<img width="200" alt="typography-code" src="https://user-images.githubusercontent.com/45376611/169308022-8dedd932-b8af-44fe-a50d-230e3bf97d89.png">
</span>

### style 이 Array type일 경우
```
    <Text presets={['h1', 'light']} style={[styles.textBg, styles.successText]}>
      Array style text
    </Text>
```
![Uploading Simulator Screen Shot - iPhone 13 - 2022-05-21 at 14.13.24.png…]()

### style 이 object type 일 경우
```
    <Text presets={['h1', 'light']} style={styles.successText}>
      Array style text
    </Text>
```
<img width="200" alt="object-type" src="https://user-images.githubusercontent.com/45376611/169636624-cd878dc2-ba7c-428b-adb3-9973f3f2c30c.png">

