### PR TITLE
feat: Stack Navigate 환경의 프로필 페이지에서 백버튼 구현

### DIFF
--- a/src/components/Profile/ProfileHeader.tsx
+++ b/src/components/Profile/ProfileHeader.tsx
@@ -1,29 +1,35 @@
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
-import { Notification, Setting } from '@shared/Icons';
+import { MainStackScreenProps } from '@/pages/MainStack/Stack';
+import { useNavigation } from '@react-navigation/native';
+import { ArrowLeft, Notification, Setting } from '@shared/Icons';
 
-const ProfileHeader = () => {
+interface ProfileHeaderProps {
+  showBackButton: boolean;
+}
+
+const ProfileHeader = ({ showBackButton }: ProfileHeaderProps) => {
+  const { goBack } = useNavigation<MainStackScreenProps<'Profile'>['navigation']>();
+
   return (
-    <View style={styles.header}>
-      <View style={styles.iconWrapper}>
-        <View style={styles.notificationIcon}>
-          <Notification />
+    <View style={propStyles(showBackButton).header}>
+      {showBackButton ? (
+        <ArrowLeft onPress={goBack} />
+      ) : (
+        <View style={styles.iconWrapper}>
+          <View style={styles.notificationIcon}>
+            <Notification />
+          </View>
+          <View>
+            <Setting />
+          </View>
         </View>
-        <View>
-          <Setting />
-        </View>
-      </View>
+      )}
     </View>
   );
 };
 
 const styles = StyleSheet.create({
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    height: 52,
-  },
   iconWrapper: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -32,5 +38,15 @@ const styles = StyleSheet.create({
     marginRight: 12,
   },
 });
+
+const propStyles = (showBackButton: boolean) =>
+  StyleSheet.create({
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: showBackButton ? 'flex-start' : 'flex-end',
+      height: 52,
+    },
+  });
 
 export { ProfileHeader };

--- a/src/components/Shared/Icons/arrow_left.svg
+++ b/src/components/Shared/Icons/arrow_left.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16.5 20.5L7.5 11.5L16.5 2.5" stroke="#222222" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/Shared/Icons/index.ts
+++ b/src/components/Shared/Icons/index.ts
@@ -36,3 +36,4 @@ export * from './NavReport';
 export * from './Notification';
 
 export { default as Setting } from './setting.svg';
+export { default as ArrowLeft } from './arrow_left.svg';

--- a/src/pages/MainStack/ProfileStack/Profile.tsx
+++ b/src/pages/MainStack/ProfileStack/Profile.tsx
@@ -1,14 +1,41 @@
 import React from 'react';
 import { SafeAreaView, StyleSheet, View } from 'react-native';
 import { ProfileHeader } from '@/components/Profile/ProfileHeader';
+import { MainStackScreenProps } from '@/pages/MainStack/Stack';
+import { useNavigation } from '@react-navigation/native';
+import { Button } from '@shared/Button/Button';
 import { Text } from '@shared/Text';
 
-const Profile = () => {
+interface ProfileProps {
+  navigation: MainStackScreenProps<'Profile'>;
+}
+
+const Profile = ({ navigation }: ProfileProps) => {
+  {
+    /* TODO: navigate 시 back button header 테스트를 위한 임시 코드. 테스트 이후 제거 예정 */
+  }
+  const { navigate } = useNavigation();
+
+  // bottom tab에서 프로필 페이지에 접근한 경우, navigation 객체에 jumpTo property가 존재하므로 jumpTo로 backButton을 보여줄 것인지 트리거
+  // @ts-ignore
+  const showBackButton = navigation.jumpTo === undefined;
+
   return (
     <SafeAreaView>
       <View style={styles.layout}>
-        <ProfileHeader />
+        <ProfileHeader showBackButton={showBackButton} />
         <Text>Profile</Text>
+
+        {/* TODO: navigate 시 back button header 테스트를 위한 임시 코드. 테스트 이후 제거 예정 */}
+        <Button
+          onPress={() => {
+            navigate('MainStack', {
+              screen: 'Profile',
+            });
+          }}
+        >
+          다른 사람 프로필 보러가기
+        </Button>
       </View>
     </SafeAreaView>
   );

--- a/src/pages/MainStack/ProfileStack/Stack.tsx
+++ b/src/pages/MainStack/ProfileStack/Stack.tsx
@@ -22,7 +22,7 @@ export type MainStackParamList = {
   Search: undefined;
   ReportBakeryModal: undefined;
   NotificationModal: undefined;
-  ProfileModal: undefined;
+  Profile: undefined;
 };
 
 export type MainStackScreenProps<T extends keyof MainStackParamList> = CompositeScreenProps<
@@ -58,7 +58,7 @@ const ProfileStack = () => {
         />
         <Stack.Screen name={'ReportBakeryModal'} component={ReportBakery} />
         <Stack.Screen name={'NotificationModal'} component={Notification} />
-        <Stack.Screen name={'ProfileModal'} component={Profile} />
+        <Stack.Screen name={'Profile'} component={Profile} />
       </Stack.Group>
     </Stack.Navigator>
   );

--- a/src/pages/MainStack/Stack.tsx
+++ b/src/pages/MainStack/Stack.tsx
@@ -20,7 +20,7 @@ export type MainStackParamList = {
   Search: undefined;
   ReportBakeryStack: NavigatorScreenParams<ReportBakeryStackParamList>;
   NotificationModal: undefined;
-  Profile: NavigatorScreenParams<MainTabParamList>;
+  Profile: undefined;
 };
 
 export type MainStackScreenProps<T extends keyof MainStackParamList> = CompositeScreenProps<


### PR DESCRIPTION
## 개요 및 변경 사항 <!-- 해당 Pull Request에 대한 간단한 설명 작성 -->
- [feat: Stack Navigate 환경의 프로필 페이지에서 백버튼 구현](https://github.com/daedongbread/bread-map-mobile/commit/7a4d10756f086e1ca45b3e939f6878c6d6381d68)

## 관련 이슈 <!-- 해당 Pull Request에 대한 자세한 내용을 확인할 수 있는 이슈를 번호로 작성 -->
- [trello](https://trello.com/c/UuKAcQfN/11-7-%ED%94%84%EB%A1%9C%ED%95%84)

closes <!-- Ex. closes #1 -->

## 추가 구현 필요사항
- 테스트 코드 제거

## 스크린샷 <!-- 빠른 참고 용 -->
https://user-images.githubusercontent.com/48236404/184471575-32a4fa45-f04f-44e2-bc07-308159e4ed4e.mov


