### PR TITLE
feat: 프로필 정보 layout 작업

### DIFF
--- a/src/components/Profile/ProfileInfo/FollowInfo/index.tsx
+++ b/src/components/Profile/ProfileInfo/FollowInfo/index.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Text } from '@/components/Shared/Text';
+import { theme } from '@/styles/theme';
+
+const FollowInfo = () => {
+  return (
+    <View style={styles.followWrapper}>
+      <Text style={styles.followText}>팔로잉</Text>
+      <Text style={styles.count}>0</Text>
+
+      <View style={styles.divider} />
+
+      <Text style={styles.followText}>팔로워</Text>
+      <Text style={styles.count}>100</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  followWrapper: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  followText: {
+    fontSize: 12,
+    lineHeight: 12,
+    color: theme.color.gray500,
+    marginRight: 2,
+    fontWeight: '400',
+  },
+  count: {
+    fontSize: 12,
+    color: theme.color.gray700,
+    fontWeight: '500',
+  },
+  divider: {
+    width: 1,
+    height: 8,
+    backgroundColor: theme.color.gray300,
+    marginHorizontal: 8,
+  },
+});
+
+export { FollowInfo };

--- a/src/components/Profile/ProfileInfo/index.tsx
+++ b/src/components/Profile/ProfileInfo/index.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Button } from '@/components/Shared/Button/Button';
+import { Text } from '@/components/Shared/Text';
+import { FollowInfo } from './FollowInfo';
+
+interface ProfileInfoProps {
+  isTabNavigated: boolean;
+}
+
+const ProfileInfo = ({ isTabNavigated }: ProfileInfoProps) => {
+  return (
+    <View style={styles.container}>
+      <View style={styles.flexBox}>
+        <View style={styles.profileImage} />
+
+        <View style={styles.infoWrapper}>
+          <Text presets={['body1', 'bold']} style={styles.nickname}>
+            빵순이님
+          </Text>
+
+          <FollowInfo />
+        </View>
+      </View>
+
+      <View style={styles.buttonWrapper}>
+        <Button appearance={isTabNavigated ? 'secondary' : 'terdary'} style={styles.buttonStyle}>
+          {isTabNavigated ? '팔로우' : '수정'}
+        </Button>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    height: 60,
+  },
+  flexBox: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  buttonWrapper: {
+    padding: 0,
+  },
+  buttonStyle: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    paddingVertical: 4,
+  },
+  profileImage: {
+    width: 60,
+    height: 60,
+    backgroundColor: 'gray',
+    marginRight: 16,
+  },
+  infoWrapper: {
+    flexDirection: 'column',
+  },
+  nickname: {
+    marginBottom: 6,
+  },
+});
+
+export { ProfileInfo };

--- a/src/components/Shared/Button/Button.tsx
+++ b/src/components/Shared/Button/Button.tsx
@@ -30,7 +30,7 @@ export const Button: React.FC<Props> = ({
   return (
     <View style={style}>
       <TouchableOpacity {...rest}>
-        <View style={[appearanceStyle, sizeStyle, defaultStyles.common]}>
+        <View style={[appearanceStyle, sizeStyle, defaultStyles.common, style]}>
           {icon && <PlusIcon color={iconColor} style={defaultStyles.icon} />}
           <Text style={textStyle} presets={['body1', 'bold']}>
             {children}

--- a/src/pages/MainStack/ProfileStack/Profile.tsx
+++ b/src/pages/MainStack/ProfileStack/Profile.tsx
@@ -9,10 +9,6 @@ interface ProfileProps {
 }
 
 const Profile = ({ navigation }: ProfileProps) => {
-  {
-    /* TODO: navigate 시 back button header 테스트를 위한 임시 코드. 테스트 이후 제거 예정 */
-  }
-
   // bottom tab에서 프로필 페이지에 접근한 경우, navigation 객체에 jumpTo property가 존재하므로 jumpTo로 backButton을 보여줄 것인지 트리거
   // @ts-ignore
   const isTabNavigated = navigation.jumpTo === undefined;

--- a/src/pages/MainStack/ProfileStack/Profile.tsx
+++ b/src/pages/MainStack/ProfileStack/Profile.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import { SafeAreaView, StyleSheet, View } from 'react-native';
 import { ProfileHeader } from '@/components/Profile/ProfileHeader';
+import { ProfileInfo } from '@/components/Profile/ProfileInfo';
 import { MainStackScreenProps } from '@/pages/MainStack/Stack';
-import { useNavigation } from '@react-navigation/native';
-import { Button } from '@shared/Button/Button';
-import { Text } from '@shared/Text';
 
 interface ProfileProps {
   navigation: MainStackScreenProps<'Profile'>;
@@ -14,28 +12,17 @@ const Profile = ({ navigation }: ProfileProps) => {
   {
     /* TODO: navigate 시 back button header 테스트를 위한 임시 코드. 테스트 이후 제거 예정 */
   }
-  const { navigate } = useNavigation();
 
   // bottom tab에서 프로필 페이지에 접근한 경우, navigation 객체에 jumpTo property가 존재하므로 jumpTo로 backButton을 보여줄 것인지 트리거
   // @ts-ignore
-  const showBackButton = navigation.jumpTo === undefined;
+  const isTabNavigated = navigation.jumpTo === undefined;
 
   return (
     <SafeAreaView>
       <View style={styles.layout}>
-        <ProfileHeader showBackButton={showBackButton} />
-        <Text>Profile</Text>
+        <ProfileHeader showBackButton={isTabNavigated} />
 
-        {/* TODO: navigate 시 back button header 테스트를 위한 임시 코드. 테스트 이후 제거 예정 */}
-        <Button
-          onPress={() => {
-            navigate('MainStack', {
-              screen: 'Profile',
-            });
-          }}
-        >
-          다른 사람 프로필 보러가기
-        </Button>
+        <ProfileInfo isTabNavigated={isTabNavigated} />
       </View>
     </SafeAreaView>
   );


### PR DESCRIPTION
## 개요 및 변경 사항 <!-- 해당 Pull Request에 대한 간단한 설명 작성 -->
- ProfileInfo 컴포넌트 생성
- FollowInfo 컴포넌트 생성
- Button 컴포넌트에 커스텀 스타일을 추가할 수 있도록 style prop도 적용되게 수정
- tabNavigate 된 것을 상대방 프로필 확인 페이지로 접근한 것을 간주하고 `showBackButton` 변수를 범용적인 `isTabNavigated`로 수정
    - 해당 변수를 Profile 페이지 내에서 여러 컴포넌트들이 사용하게 되면 Context로 관리될 수 있음

## 관련 이슈 <!-- 해당 Pull Request에 대한 자세한 내용을 확인할 수 있는 이슈를 번호로 작성 -->

closes <!-- Ex. closes #1 -->

## 추가 구현 필요사항

## 스크린샷 <!-- 빠른 참고 용 -->
<img width="422" alt="image" src="https://user-images.githubusercontent.com/48236404/185613158-49a836ee-6890-488a-b995-e8b55fc51f4c.png">

