### PR TITLE
Feat/search history

### DIFF
--- a/src/apis/bakery/useSearch.ts
+++ b/src/apis/bakery/useSearch.ts
@@ -3,7 +3,7 @@ import { fetcher } from '../fetcher';
 
 export type SearchEntity = {
   bakeryId: number;
-  bakeryName: number;
+  bakeryName: string;
   reviewNum: number;
   distance: number;
 };

--- a/src/components/Search/HistoryItem.tsx
+++ b/src/components/Search/HistoryItem.tsx
@@ -1,20 +1,23 @@
 import React, { memo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Pressable, StyleSheet, View } from 'react-native';
 import { BreadCakeIcon } from '@shared/Icons';
 import { Text } from '@shared/Text';
 
 type Props = {
   name: string;
+  onPress: () => void;
 };
 
-const HistoryItem: React.FC<Props> = memo(({ name }) => {
+const HistoryItem: React.FC<Props> = memo(({ name, onPress }) => {
   return (
-    <View style={styles.container}>
-      <View style={styles.iconContainer}>
-        <BreadCakeIcon width={26} height={26} />
+    <Pressable onPress={onPress}>
+      <View style={styles.container}>
+        <View style={styles.iconContainer}>
+          <BreadCakeIcon width={26} height={26} />
+        </View>
+        <Text presets={['body1', 'regular']}>{name}</Text>
       </View>
-      <Text presets={['body1', 'regular']}>{name}</Text>
-    </View>
+    </Pressable>
   );
 });
 

--- a/src/components/Search/SearchBakeryList.tsx
+++ b/src/components/Search/SearchBakeryList.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback } from 'react';
-import { ButtonProps, FlatList, FlatListProps, StyleSheet } from 'react-native';
+import { ButtonProps, FlatList, ListRenderItem, StyleSheet } from 'react-native';
 import { SearchEntity } from '@/apis/bakery/useSearch';
 import { Divider } from '@/components/BakeryDetail/Divider';
 import { SearchedBakeryNotFound } from '@/components/Search/SearchedBakeryNotFound';
@@ -12,15 +12,16 @@ const ItemSeparatorComponent: React.VFC = memo(() => {
 type Props = {
   bakeries: Array<SearchEntity>;
   onPressReport: ButtonProps['onPress'];
-  onPressBakery: (id: number) => void;
+  onPressBakery: (searchEntity: SearchEntity) => void;
 };
 
 const SearchBakeryList: React.FC<Props> = memo(({ bakeries, onPressBakery, onPressReport }) => {
-  const renderItem: FlatListProps<SearchEntity>['renderItem'] = useCallback(
+  const renderItem: ListRenderItem<SearchEntity> = useCallback(
     ({ item }) => {
       const onPress = () => {
-        onPressBakery(item.id);
+        onPressBakery(item);
       };
+
       return <SearchItem bakery={item} onPress={onPress} />;
     },
     [onPressBakery]

--- a/src/components/Search/SearchHistoryList.tsx
+++ b/src/components/Search/SearchHistoryList.tsx
@@ -1,23 +1,29 @@
 import React, { memo } from 'react';
 import { FlatList, ListRenderItem, StyleSheet, View } from 'react-native';
+import { SearchEntity } from '@/apis/bakery/useSearch';
 import { Divider } from '@/components/BakeryDetail/Divider';
 import { HistoryItem } from '@/components/Search/HistoryItem';
 import { theme } from '@/styles/theme';
 import { Text } from '@shared/Text';
-
-const renderItem: ListRenderItem<string> = ({ item }) => {
-  return <HistoryItem name={item} />;
-};
 
 const ItemSeparatorComponent: React.VFC = () => {
   return <Divider style={styles.divider} />;
 };
 
 type Props = {
-  searchHistory: Array<string>;
+  searchHistory: SearchEntity[];
+  onPressBakery: (searchEntity: SearchEntity) => void;
 };
 
-const SearchHistoryList: React.FC<Props> = memo(({ searchHistory }) => {
+const SearchHistoryList: React.FC<Props> = memo(({ searchHistory, onPressBakery }) => {
+  const renderItem: ListRenderItem<SearchEntity> = ({ item }) => {
+    const onPress = () => {
+      onPressBakery(item);
+    };
+
+    return <HistoryItem name={item.bakeryName} onPress={onPress} />;
+  };
+
   if (!searchHistory?.length) {
     return (
       <View style={styles.emptyContainer}>

--- a/src/components/Search/SearchItem.tsx
+++ b/src/components/Search/SearchItem.tsx
@@ -1,17 +1,13 @@
 import React, { memo } from 'react';
 import { ButtonProps, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { SearchEntity } from '@/apis/bakery/useSearch';
 import { theme } from '@/styles/theme';
 import { convertDistance } from '@/utils/convert/convert';
 import { BreadCakeIcon } from '@shared/Icons';
 import { Text } from '@shared/Text';
 
 type Props = {
-  bakery: {
-    id: number;
-    name: string;
-    reviews: Array<number>;
-    distance: number;
-  };
+  bakery: SearchEntity;
   onPress: ButtonProps['onPress'];
 };
 
@@ -19,13 +15,13 @@ const SearchItem: React.FC<Props> = memo(({ bakery, onPress }) => {
   return (
     <TouchableOpacity onPress={onPress}>
       <View style={styles.container}>
-        <View style={styles.iconContainer}>
+        <View style={styles.iconWrapper}>
           <BreadCakeIcon width={26} height={26} />
         </View>
-        <View style={{ flex: 1 }}>
-          <Text presets={['body1', 'regular']}>{bakery.name}</Text>
+        <View style={styles.wrapper}>
+          <Text presets={['body1', 'regular']}>{bakery.bakeryName}</Text>
           <Text presets={['caption1', 'regular']} style={styles.hint}>
-            리뷰 {bakery.reviews.length}
+            리뷰 {bakery.reviewNum}
           </Text>
         </View>
         <Text style={styles.hint}>{convertDistance(bakery.distance)}</Text>
@@ -40,8 +36,11 @@ const styles = StyleSheet.create({
     paddingVertical: 13,
     alignItems: 'center',
   },
-  iconContainer: {
+  iconWrapper: {
     marginRight: 8,
+  },
+  wrapper: {
+    flex: 1,
   },
   hint: {
     color: theme.color.gray500,

--- a/src/pages/MainStack/MainTab/HomeStack/Bakery/BakeryHome.tsx
+++ b/src/pages/MainStack/MainTab/HomeStack/Bakery/BakeryHome.tsx
@@ -25,9 +25,9 @@ import { resizePixels } from '@/utils';
 const BakeryHome: React.FC<BakeryDetailTabScreenProps<'BakeryDetailHome'>> = ({ route }) => {
   const { bakery, updateBakery } = useBakeryDetail();
 
-  React.useEffect(() => {
-    updateBakery(route.params);
-  }, [updateBakery, route.params]);
+  // React.useEffect(() => {
+  //   updateBakery(route.params);
+  // }, [updateBakery, route.params]);
 
   return (
     <ScrollView>

--- a/src/pages/MainStack/Search/Search.tsx
+++ b/src/pages/MainStack/Search/Search.tsx
@@ -1,13 +1,13 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { SafeAreaView, StyleSheet, View } from 'react-native';
-import { useSearchQuery } from '@/apis/bakery/useSearch';
+import { SearchEntity, useSearchQuery } from '@/apis/bakery/useSearch';
 import { SearchBakeryList } from '@/components/Search/SearchBakeryList';
 import { SearchHistoryList } from '@/components/Search/SearchHistoryList';
 import { useDebounce } from '@/hooks/useDebounce';
 import { useGeolocation } from '@/hooks/useGeolocation';
 import { Header } from '@/pages/MainStack/Search/Header';
 import { MainStackScreenProps } from '@/pages/MainStack/Stack';
-import { storage } from '@/utils/storage/storage';
+import { getStorageSearchHistory, setStorageSearchHistory } from '@/utils/storage/searchHistory';
 import { Text } from '@shared/Text';
 
 type Props = MainStackScreenProps<'Search'>;
@@ -15,7 +15,7 @@ type Props = MainStackScreenProps<'Search'>;
 const Search: React.FC<Props> = ({ navigation }) => {
   const { currentPosition, getLocation } = useGeolocation();
   const [searchValue, setSearchValue] = useState('');
-  const [searchHistory, setSearchHistory] = useState<Array<string>>([]);
+  const [searchHistory, setSearchHistory] = useState<SearchEntity[]>([]);
 
   const word = useDebounce(searchValue, 300);
 
@@ -25,11 +25,11 @@ const Search: React.FC<Props> = ({ navigation }) => {
     latitude: currentPosition?.latitude,
   });
 
-  const goBack = useCallback(() => {
+  const goBack = () => {
     if (navigation.canGoBack()) {
       navigation.pop();
     }
-  }, [navigation]);
+  };
 
   const navigateReport = useCallback(() => {
     navigation.push('ReportBakeryStack', {
@@ -55,17 +55,28 @@ const Search: React.FC<Props> = ({ navigation }) => {
     [navigation]
   );
 
+  const appendSearchHistory = useCallback((searchEntity: SearchEntity) => {
+    setSearchHistory(prevState => {
+      const newSearchHistory = [searchEntity, ...prevState.filter(el => el.bakeryId !== searchEntity.bakeryId)];
+
+      setStorageSearchHistory(newSearchHistory);
+
+      return newSearchHistory;
+    });
+  }, []);
+
+  const onPressBakery = useCallback(
+    (searchEntity: SearchEntity) => {
+      navigateDetail(searchEntity.bakeryId);
+      appendSearchHistory(searchEntity);
+    },
+    [appendSearchHistory, navigateDetail]
+  );
+
   useEffect(() => {
-    const getSearchHistory = async () => {
-      const res = await storage.get('search');
-      if (!res) {
-        return;
-      }
-
-      return JSON.parse(res);
-    };
-
-    getSearchHistory().then(setSearchHistory);
+    getStorageSearchHistory().then(el => {
+      setSearchHistory(el);
+    });
   }, []);
 
   useEffect(() => {
@@ -77,13 +88,13 @@ const Search: React.FC<Props> = ({ navigation }) => {
       <Header value={searchValue} onChangeText={setSearchValue} onPress={goBack} />
       <View style={styles.container}>
         {data?.length ? (
-          <SearchBakeryList bakeries={data} onPressReport={navigateReport} onPressBakery={navigateDetail} />
+          <SearchBakeryList bakeries={data} onPressReport={navigateReport} onPressBakery={onPressBakery} />
         ) : (
           <>
             <Text presets={['body1', 'bold']} style={styles.historyTitle}>
               최근검색
             </Text>
-            <SearchHistoryList searchHistory={searchHistory} />
+            <SearchHistoryList searchHistory={searchHistory} onPressBakery={onPressBakery} />
           </>
         )}
       </View>

--- a/src/utils/storage/searchHistory.ts
+++ b/src/utils/storage/searchHistory.ts
@@ -1,0 +1,15 @@
+import { SearchEntity } from '@/apis/bakery/useSearch';
+import { storage } from '@/utils/storage/storage';
+
+export const getStorageSearchHistory = async (): Promise<SearchEntity[]> => {
+  const res = await storage.get('search');
+  if (!res) {
+    return [];
+  }
+
+  return JSON.parse(res);
+};
+
+export const setStorageSearchHistory = (searchHistory: SearchEntity[]) => {
+  storage.set('search', searchHistory);
+};

--- a/src/utils/storage/storage.ts
+++ b/src/utils/storage/storage.ts
@@ -4,8 +4,10 @@ class Storage {
   public async get(key: string) {
     return EncryptedStorage.getItem(key);
   }
-  public async set(key: string, value: string) {
-    return EncryptedStorage.setItem(key, value);
+  public async set(key: string, value: unknown) {
+    const stringifyValue = JSON.stringify(value);
+
+    return EncryptedStorage.setItem(key, stringifyValue);
   }
 }
 


### PR DESCRIPTION
## 개요 및 변경 사항 <!-- 해당 Pull Request에 대한 간단한 설명 작성 -->
검색을 해서 검색된 결과를 클릭할경우, history 를 storage 에 저장하여, 앱을 종료한 이후에도 최근 검색어에 뜨게 작업했습니다.

text input 이 있어서 re-rendering 을 방지하고자, search list, search history list 에 useCallback 을 적용했습니다.
(header 은 memorizing 이 불필요할거라고 예상하여 진행하지 않았습니다.)

작업을 진행하다보면 style 에 { flex: 1 } 을 넣게되는 경우가 많은데, 그럴때마다 이름짓기가 어려운거같아요..! 그래서 자주 쓰이는 공통 style 을 tailwindcss 와 비슷한 naming 을 사용하여 사용하는건 어떠신가요?

ex)
```jsx
import { flex1 } from "@/common/styles"

<View style={[flex1, styles.container]}>
</View>

const styles = StylesSheet.create({
  container: {
    ...
    }
})
```

## 관련 이슈 <!-- 해당 Pull Request에 대한 자세한 내용을 확인할 수 있는 이슈를 번호로 작성 -->

closes <!-- Ex. closes #1 -->

## 추가 구현 필요사항

## 스크린샷 <!-- 빠른 참고 용 -->
![Simulator Screen Recording - iPhone 11 - 2022-08-24 at 08 17 02](https://user-images.githubusercontent.com/45376611/186282797-0b74ca92-5a6f-401c-b872-5725b44c5280.gif)

