### PR TITLE
Feat/home rank 8.1 version QA

### DIFF
--- a/src/apis/auth/useFollow.ts
+++ b/src/apis/auth/useFollow.ts
@@ -1,18 +1,26 @@
 import { useMutation } from 'react-query';
 import { UseMutationOptions } from 'react-query/types/react/types';
 import { fetcher } from '@/apis/fetcher';
+import { unFollow } from '@/apis/profile';
 
 type PostFollowProps = {
   userId: number;
 };
 
 const postFollow = ({ userId }: PostFollowProps): Promise<void> => {
-  return fetcher.post('/v1/users/follow', { userId }).then(res => res.data());
+  return fetcher.post('/v1/users/follow', { userId }).then(res => res.data);
 };
 
 export const useFollow = (options: UseMutationOptions<void, unknown, PostFollowProps, any>) => {
   return useMutation({
     mutationFn: postFollow,
     ...options,
+  });
+};
+
+export const useUnFollow = () => {
+  return useMutation({
+    mutationFn: unFollow,
+    mutationKey: ['follow'],
   });
 };

--- a/src/apis/bakery/useGetBakery.ts
+++ b/src/apis/bakery/useGetBakery.ts
@@ -28,4 +28,4 @@ const useGetBakery = ({ bakeryId }: UseGetBakeryProps) => {
   };
 };
 
-export { useGetBakery };
+export { useGetBakery, requestGetBakery };

--- a/src/components/NewReportedBakeries/NewBakeryCard.tsx
+++ b/src/components/NewReportedBakeries/NewBakeryCard.tsx
@@ -22,6 +22,7 @@ type Props = {
 
   onPressFollow: (userId: number) => void;
   onPressFlag: (bakery: { id: number; name: string }) => void;
+  onPressBakery: (bakery: { id: number; name: string }) => void;
 };
 export const NewBakeryCard = ({
   id,
@@ -36,6 +37,7 @@ export const NewBakeryCard = ({
   isFollow,
   onPressFollow,
   onPressFlag,
+  onPressBakery,
 }: Props) => {
   const handlePressFollow = () => {
     if (userId) {
@@ -47,7 +49,10 @@ export const NewBakeryCard = ({
     onPressFlag({ id, name });
   };
 
-  console.log(image);
+  const handlePressBakery = () => {
+    onPressBakery({ id, name });
+  };
+
   return (
     <View style={styles.container}>
       <View style={[styles.row, styles.center, styles.userSection]}>
@@ -68,31 +73,33 @@ export const NewBakeryCard = ({
           </Button>
         </View>
       </View>
-      <View style={styles.row}>
-        <View style={styles.rightGap}>
-          <Image source={{ uri: image || '' }} width={100} height={100} style={styles.bakeryImage} />
-        </View>
-        <View style={styles.bakeryInfo}>
-          <View style={[styles.row, styles.spaceBetween]}>
-            <View>
-              <Text presets={['body2', 'semibold']} color={'gray900'} style={styles.bottomGap}>
-                {name}
+      <TouchableOpacity onPress={handlePressBakery}>
+        <View style={styles.row}>
+          <View style={styles.rightGap}>
+            <Image source={{ uri: image || '' }} width={100} height={100} style={styles.bakeryImage} />
+          </View>
+          <View style={styles.bakeryInfo}>
+            <View style={[styles.row, styles.spaceBetween]}>
+              <View>
+                <Text presets={['body2', 'semibold']} color={'gray900'} style={[styles.bottomGap, styles.nameText]}>
+                  {name}
+                </Text>
+                <ShortAddress shortAddress={shortAddress} />
+              </View>
+              <View style={[styles.flagContainer]}>
+                <TouchableOpacity onPress={handlePressFlag}>
+                  <IcReport width={28} height={28} style={isFlag ? styles.primaryColor : styles.dimColor} />
+                </TouchableOpacity>
+              </View>
+            </View>
+            <View style={styles.reviewContainer}>
+              <Text style={styles.reviewText} color={'gray900'}>
+                {content}
               </Text>
-              <ShortAddress shortAddress={shortAddress} />
             </View>
-            <View style={[styles.flagContainer]}>
-              <TouchableOpacity onPress={handlePressFlag}>
-                <IcReport width={28} height={28} style={isFlag ? styles.primaryColor : styles.dimColor} />
-              </TouchableOpacity>
-            </View>
-          </View>
-          <View style={styles.reviewContainer}>
-            <Text style={styles.reviewText} color={'gray900'}>
-              {content}
-            </Text>
           </View>
         </View>
-      </View>
+      </TouchableOpacity>
     </View>
   );
 };
@@ -133,6 +140,9 @@ const styles = StyleSheet.create({
     height: 20,
     borderRadius: 10,
   },
+  nameText: {
+    lineHeight: 15,
+  },
   followText: {
     fontSize: 12,
   },
@@ -144,6 +154,7 @@ const styles = StyleSheet.create({
   },
   bakeryInfo: {
     flex: 1,
+    height: 100,
   },
   bakeryImage: {
     width: 100,
@@ -153,7 +164,7 @@ const styles = StyleSheet.create({
   reviewContainer: {
     backgroundColor: theme.color.gray100,
     flex: 1,
-    height: 52,
+    height: 51,
     paddingHorizontal: 10,
     paddingVertical: 11,
   },

--- a/src/components/RankBakeries/Rating.tsx
+++ b/src/components/RankBakeries/Rating.tsx
@@ -7,12 +7,12 @@ import { Text } from '@shared/Text';
 
 export const Rating = (props: { flagNum: number; rating: number }) => {
   return (
-    <View style={[styles.row]}>
+    <View style={[styles.row, styles.alignCenter]}>
       <View style={[styles.row, styles.alignCenter, styles.reportIconWrapper]}>
         <View style={styles.icon}>
           <IcReport style={styles.primaryColor} />
         </View>
-        <Text presets={['caption1']} style={styles.shortAddress} color={'gray900'}>
+        <Text presets={['caption1']} style={[styles.shortAddress, styles.scoreText]} color={'gray900'}>
           {props.flagNum}
         </Text>
       </View>
@@ -20,7 +20,7 @@ export const Rating = (props: { flagNum: number; rating: number }) => {
         <View style={styles.icon}>
           <IcStart style={styles.primaryColor} />
         </View>
-        <Text presets={['caption1']} style={styles.shortAddress} color={'gray900'}>
+        <Text presets={['caption1']} style={[styles.shortAddress, styles.scoreText]} color={'gray900'}>
           {props.rating}
         </Text>
       </View>
@@ -55,5 +55,8 @@ const styles = StyleSheet.create({
   },
   shortAddress: {
     lineHeight: 13,
+  },
+  scoreText: {
+    lineHeight: 16,
   },
 });

--- a/src/components/RankBakeries/ShortAddress.tsx
+++ b/src/components/RankBakeries/ShortAddress.tsx
@@ -29,6 +29,6 @@ const styles = StyleSheet.create({
     height: 15,
   },
   shortAddress: {
-    lineHeight: 13,
+    lineHeight: 15,
   },
 });

--- a/src/components/RankBakeries/index.tsx
+++ b/src/components/RankBakeries/index.tsx
@@ -24,7 +24,9 @@ export const RankBakeries = ({ bakeries, onPressBakery, onPressFlag }: Props) =>
           <TouchableOpacity onPress={() => onPressBakery(item)}>
             <View style={[styles.row]}>
               <View style={[styles.row, styles.center, styles.imageWrapper]}>
-                <Text presets={['subhead', 'medium']} style={styles.rankingIndex}>{index + 1}</Text>
+                <Text presets={['subhead', 'medium']} style={styles.rankingIndex}>
+                  {index + 1}
+                </Text>
                 <Image source={item.image ? { uri: item.image } : defaultThumbnail} style={styles.image} />
               </View>
               <View style={styles.contentWrapper}>
@@ -32,7 +34,7 @@ export const RankBakeries = ({ bakeries, onPressBakery, onPressFlag }: Props) =>
                   {item.name}
                 </Text>
                 <ShortAddress shortAddress={item.shortAddress} />
-                <Rating rating={item.rating} flagNum={item.flagNum} />
+                <Rating rating={item.rating || 0} flagNum={item.flagNum || 0} />
               </View>
               <View style={[styles.center]}>
                 <TouchableOpacity onPress={() => onPressFlag(item)}>

--- a/src/components/Shared/Text/Text.tsx
+++ b/src/components/Shared/Text/Text.tsx
@@ -6,9 +6,10 @@ import { presets as textPresets, TextPresets } from '@shared/Text/presets';
 type Props = TextProps & {
   presets?: TextPresets | Array<TextPresets>;
   color?: string | keyof typeof theme['color'];
+  lineHeight?: number;
 };
 
-export const Text: React.FC<Props> = memo(({ presets, style: styleOverride, color, ...rest }) => {
+export const Text: React.FC<Props> = memo(({ presets, style: styleOverride, color, lineHeight, ...rest }) => {
   const parsingPresets = useCallback(() => {
     if (!presets) {
       return [{}];
@@ -25,9 +26,12 @@ export const Text: React.FC<Props> = memo(({ presets, style: styleOverride, colo
     color: {
       color: color && color in theme.color ? theme.color[color as keyof typeof theme.color] : color,
     },
+    lineHeight: {
+      lineHeight: lineHeight,
+    },
   });
 
-  const style = [...parsingPresets(), styles.color, styleOverride];
+  const style = [...parsingPresets(), styles.color, styles.lineHeight, styleOverride];
 
   return <ReactNativeText style={style} {...rest} />;
 });


### PR DESCRIPTION
## 개요 및 변경 사항 <!-- 해당 Pull Request에 대한 간단한 설명 작성 -->
[랭킹팀 8.1 ver QA](https://www.figma.com/file/Y0rbvt5gXZtP1WUvS64uL7/DDS?type=design&node-id=10888-121621&mode=design&t=133DKiXdCSrSz7Ht-4)

### 디자인
- 홈 랭킹 메인
  - 라운드 값 4 넣어주세요!
  - 깃발 개수가 나오지 않아요
  - 가운데정렬(별 / 숫자)
  - 주소 윗부분이 살짝 잘려요
  - 디자인 레이아웃이 수정되어야할 것 같아요!
- 랭킹 더보기
  - 주소 윗부분이 살짝 잘려요 (그래서 그런지 여백도 조금 좁아보입니다!)
  - 깃발 상단에 배치 부탁드립니다.
  - 깃발 개수가 나오지 않아요
- IOS
  -  여백 조정 필요해요!

### 기능
- 홈 랭킹 메인
  - 한번 더 클릭되었을 때 깃발  해제가 되어야합니다!(현재 바텀시트가 뜨고있어요)
  - 팔로우가 눌러지지 않아요 ㅠㅠ
## 추가 구현 필요사항

## 스크린샷 <!-- 빠른 참고 용 -->
